### PR TITLE
Vital System.Cache module is deprecated.

### DIFF
--- a/autoload/unite/sources/symfony_bundles.vim
+++ b/autoload/unite/sources/symfony_bundles.vim
@@ -27,7 +27,8 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:Cache = unite#util#get_vital().import('System.Cache')
+" let s:Cache = unite#util#get_vital().import('System.Cache')
+let s:Cache = unite#util#get_vital_cache()
 
 function! unite#sources#symfony_bundles#define() "{{{
     let sources = [ s:symfony_bundles]

--- a/autoload/unite/sources/symfony_entities.vim
+++ b/autoload/unite/sources/symfony_entities.vim
@@ -28,7 +28,8 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:Cache = unite#util#get_vital().import('System.Cache')
+" let s:Cache = unite#util#get_vital().import('System.Cache')
+let s:Cache = unite#util#get_vital_cache()
 
 function! unite#sources#symfony_entities#define() "{{{
     let sources = [ s:symfony_entities]

--- a/autoload/unite/sources/symfony_routes.vim
+++ b/autoload/unite/sources/symfony_routes.vim
@@ -28,7 +28,8 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:Cache = unite#util#get_vital().import('System.Cache')
+" let s:Cache = unite#util#get_vital().import('System.Cache')
+let s:Cache = unite#util#get_vital_cache()
 
 function! unite#sources#symfony_routes#define() "{{{
     let sources = [ s:symfony_routes_name, s:symfony_routes_pattern]

--- a/autoload/unite/sources/symfony_services.vim
+++ b/autoload/unite/sources/symfony_services.vim
@@ -28,7 +28,8 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:Cache = unite#util#get_vital().import('System.Cache')
+" let s:Cache = unite#util#get_vital().import('System.Cache')
+let s:Cache = unite#util#get_vital_cache()
 
 
 function! unite#sources#symfony_services#define() "{{{

--- a/autoload/unite/sources/symfony_tags.vim
+++ b/autoload/unite/sources/symfony_tags.vim
@@ -27,7 +27,8 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:Cache = unite#util#get_vital().import('System.Cache')
+" let s:Cache = unite#util#get_vital().import('System.Cache')
+let s:Cache = unite#util#get_vital_cache()
 
 function! unite#sources#symfony_tags#define() "{{{
     let sources = [ s:symfony_tags]


### PR DESCRIPTION
Use unite#util#get_vital_cache() to retrieve it anyway. Unite do the same since commit bb2654f.
